### PR TITLE
处理columnSpecs为null的情况

### DIFF
--- a/src/main/kotlin/wang/yuheng/Reader.kt
+++ b/src/main/kotlin/wang/yuheng/Reader.kt
@@ -41,12 +41,12 @@ interface Reader {
                 var comment = ""
                 var defaultValue = ""
 
-                val commentIndex = col.columnSpecs.map { it.toUpperCase() }.indexOf("COMMENT")
+                val commentIndex = col.columnSpecs?.map { it.toUpperCase() }?.indexOf("COMMENT") ?: -1
                 if (commentIndex > -1) {
                     comment = col.columnSpecs[commentIndex + 1]
                 }
 
-                val defaultValueIndex = col.columnSpecs.map { it.toUpperCase() }.indexOf("DEFAULT")
+                val defaultValueIndex = col.columnSpecs?.map { it.toUpperCase() }?.indexOf("DEFAULT") ?: -1
                 if (defaultValueIndex > -1) {
                     defaultValue = col.columnSpecs[defaultValueIndex + 1]
                 }
@@ -60,7 +60,7 @@ interface Reader {
                     size = Integer.parseInt(dataTypeArguments[0].toString())
                 }
 
-                val notNull = col.columnSpecs.joinToString(",").toUpperCase().contains("NOT,NULL")
+                val notNull = col.columnSpecs?.joinToString(",")?.toUpperCase()?.contains("NOT,NULL") ?: false
                 Column(name, comment, dataType.dataType, size, defaultValue, notNull)
             }.collect(Collectors.toList())
     }


### PR DESCRIPTION
在处理类似于
```SQL
CREATE TABLE IF NOT EXISTS example_table (
    id INT AUTO_INCREMENT PRIMARY KEY,
    name VARCHAR(100) NOT NULL,
    age INT NOT NULL,
    email VARCHAR(100),
    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
);
```
这种语句时，email这一行只有列名和类型，没有额外的约束，会导致代码中col.columnSpecs为null，抛出空指针异常，可以通过添加默认值的方式解决。
```
java.lang.NullPointerException: getColumnSpecs(...) must not be null
	at wang.yuheng.Reader$extractColumn$1.invoke(Reader.kt:44)
	at wang.yuheng.Reader$extractColumn$1.invoke(Reader.kt:39)
```
不过这种方式生成的puml文件也是没有默认值的（下面的email行），我不确定要不要把defaultValue初始化为“NULL”，不知道符不符合所有SQL语言的默认行为
```puml
@startuml
!define Table(name,desc) class name as "desc" << (T,#FFAAAA) >>
!define primary_key(x) <color:red><b>x</b></color>
!define unique(x) <color:green>x</color>
!define not_null(x) <u>x</u>
hide methods
hide stereotypes

Table(example_table, "example_table\n(null)") {
  id INT  
  not_null(name) VARCHAR  
  not_null(age) INT  
  email VARCHAR  
  created_at TIMESTAMP CURRENT_TIMESTAMP 
}
@enduml
```